### PR TITLE
Switch to Adobe SourceCodePro font

### DIFF
--- a/00-FrontMatter.md
+++ b/00-FrontMatter.md
@@ -5,8 +5,10 @@ author: Nathan Jarus and Michael Wisely
 institute: Missouri University of Science and Technology
 
 documentclass: book
-papersize: a5paper
+papersize: letter
 colorlinks: true
+
+fontfamily: sourcecodepro
 
 toc: true
 toc-depth: 0

--- a/Makefile
+++ b/Makefile
@@ -28,20 +28,20 @@ all: cs1001_prelab.pdf
 tex: cs1001_prelab.tex
 
 quick: tex
-	pdflatex cs1001_prelab.tex
+	xelatex cs1001_prelab.tex
 
 book: cs1001_prelab.pdf
 	pdfbook --short-edge --letterpaper cs1001_prelab.pdf
 	@echo -e "\n\nDone! Be sure to print that bad-boy using short-edge duplexing."
 
 cs1001_prelab.pdf: ${MD_PIECES} template.tex .commit-info.tex
-	pandoc --template=template.tex --from markdown+${EXTENSIONS} --output cs1001_prelab.pdf ${MD_PIECES}
+	pandoc --latex-engine=xelatex --template=template.tex --from markdown+${EXTENSIONS} --output cs1001_prelab.pdf ${MD_PIECES}
 
 cs1001_prelab.tex: ${MD_PIECES} template.tex .commit-info.tex
-	pandoc --template=template.tex --standalone --from markdown+${EXTENSIONS} --output cs1001_prelab.tex ${MD_PIECES}
+	pandoc --latex-engine=xelatex --template=template.tex --standalone --from markdown+${EXTENSIONS} --output cs1001_prelab.tex ${MD_PIECES}
 
 %.pdf: 00-FrontMatter.md %*.md .commit-info.tex
-	pandoc --template=template.tex --from markdown+${EXTENSIONS} --output $@ $^
+	pandoc --latex-engine=xelatex --template=template.tex --from markdown+${EXTENSIONS} --output $@ $^
 
 # .git/index is updated every time a commit, checkout, etc. occurs.
 # .dirty is updated the first time the index goes clean -> dirty.

--- a/template.tex
+++ b/template.tex
@@ -2,8 +2,30 @@
 $if(beamerarticle)$
 \usepackage{beamerarticle} % needs to be loaded first
 $endif$
+\usepackage{ifxetex,ifluatex}
 $if(fontfamily)$
+\ifxetex
+	\PassOptionsToPackage{no-math}{fontspec} % font families may load fontspec
+\fi
 \usepackage[$for(fontfamilyoptions)$$fontfamilyoptions$$sep$,$endfor$]{$fontfamily$}
+% Fix for sourcecodepro curly quotes from https://tex.stackexchange.com/questions/354873/xelatex-sourcecodepro-listings-curly-quotes-always
+% Can be removed once https://github.com/silkeh/latex-sourcecodepro/pull/5 lands in texlive...
+\makeatletter
+\defaultfontfeatures[\ttfamily] {
+	Numbers   = \sourcecodepro@figurestyle ,
+	Scale     = \SourceCodePro@scale ,
+	Extension = .otf
+}
+
+		% Monospace font
+\setmonofont [
+	UprightFont    = *-\sourcecodepro@regstyle ,
+	ItalicFont     = *-\sourcecodepro@regstyle It ,
+	BoldFont       = *-\sourcecodepro@boldstyle ,
+	BoldItalicFont = *-\sourcecodepro@boldstyle It
+]{SourceCodePro}
+\makeatother
+
 $else$
 \usepackage{lmodern}
 $endif$
@@ -12,7 +34,6 @@ $if(linestretch)$
 \setstretch{$linestretch$}
 $endif$
 \usepackage{amssymb,amsmath}
-\usepackage{ifxetex,ifluatex}
 \usepackage{fixltx2e} % provides \textsubscript
 \ifnum 0\ifxetex 1\fi\ifluatex 1\fi=0 % if pdftex
   \usepackage[$if(fontenc)$$fontenc$$else$T1$endif$]{fontenc}


### PR DESCRIPTION
Also switch to using xelatex since the T1 font is missing `` ` `` (and I think we end up switching to xelatex sometime down the road anyway).